### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cloud-gov/pages-ops @cloud-gov/studio


### PR DESCRIPTION
## Changes proposed in this pull request:

- Pages Ops and Studio owning it

## Security considerations
Owners are no assigned